### PR TITLE
[Feature/#53] 인풋 공용 컴포넌트 box-sizing 변경

### DIFF
--- a/src/components/auth/module/module.tsx
+++ b/src/components/auth/module/module.tsx
@@ -4,6 +4,7 @@ import AuthButton from '@/components/auth/authButton/authButton';
 import AuthInput from '@/components/auth/authInput/authInput';
 import CodeInput from '@/components/auth/codeInput/codeInput';
 import ValidationMessage from '@/components/auth/validationMessage/validationMessage';
+import Input from '@/components/common/input/input';
 
 import * as S from './module.style';
 
@@ -36,7 +37,7 @@ export const InputModule = React.forwardRef<HTMLInputElement, TModuleProps>(
       <S.Wrapper>
         {span && <span>{span}</span>}
         <S.Wrapper2>
-          <AuthInput
+          <Input
             placeholder={Name}
             type={inputname}
             autoComplete={inputname}

--- a/src/components/common/input/input.style.ts
+++ b/src/components/common/input/input.style.ts
@@ -1,14 +1,59 @@
 import styled from 'styled-components';
 
-type TInputWrapperProps = {
-  width?: string;
-};
+const InputWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  height: 41px;
+  border-radius: 4px;
+`;
+const Container = styled.div`
+  width: 100%;
+  border-radius: 4px;
+  display: flex;
+  gap: 5px;
+  position: relative;
+  flex-direction: column;
+`;
+const Input = styled.input<{ $isValid?: boolean }>`
+  width: 100%;
+  height: 41px;
+  padding: 0px 0px 0px 10px;
+  gap: 10px;
+  border-radius: 4px;
+  opacity: 0px;
+  font-size: 14px;
+  border: 1px solid;
+  border-color: ${(props) => (props.$isValid === false ? props.theme.colors.error.error_500 : 'none')};
+  background-color: ${(props) => (props.$isValid === false ? props.theme.colors.error.error_50 : 'white')};
+`;
 
-const InputWrapper = styled.input<TInputWrapperProps>`
+const Eyes = styled.div<{ $active?: boolean }>`
+  position: absolute;
+  z-index: 1;
+  right: 10px;
+  top: 10px;
+  svg {
+    fill: ${({ $active, theme }) => ($active ? theme.colors.gray.gray_700 : theme.colors.gray.gray_300)};
+  }
+`;
+
+const MessageWrapper = styled.div`
+  width: 100%;
+  display: flex;
+`;
+
+const MessageWrapper2 = styled.div`
+  display: flex;
+  position: absolute;
+  top: -24px;
+  right: 0;
+`;
+
+const NormalInputWrapper = styled.input<{ $width?: string }>`
   ${({ theme }) => theme.text.medium_20};
   color: ${({ theme }) => theme.colors.primary.pri_50};
   height: 64px;
-  width: ${(props) => props.width || '820px'};
+  width: 100%;
   padding: 16px 20px;
   border-radius: 4px;
   border: 1px solid rgba(153, 153, 153, 0.5);
@@ -19,4 +64,6 @@ const InputWrapper = styled.input<TInputWrapperProps>`
   }
 `;
 
-export { InputWrapper };
+export {};
+
+export { Container, Eyes, Input, InputWrapper, MessageWrapper, MessageWrapper2, NormalInputWrapper };

--- a/src/components/common/input/input.tsx
+++ b/src/components/common/input/input.tsx
@@ -1,14 +1,58 @@
-import type { ChangeEvent } from 'react';
+import React, { useState } from 'react';
 
-import * as S from '@/components/common/input/input.style';
+import * as S from './input.style';
+import ValidataionMessage from './validationMessage';
 
-type TInputProps = {
+import Eyes from '@/assets/icons/eyes.svg?react';
+
+export type TInput = {
+  placeholder: string;
+  type: 'normal' | 'password' | 'auth' | string;
+  isValid?: boolean;
+  errorMessage?: string;
+  touched?: boolean;
+  autoComplete?: string;
   value?: string;
-  placeholder?: string;
-  width?: `${number}px` | `${number}%`;
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  valid?: boolean;
+  top?: boolean;
+  ref?: any;
 };
 
-export default function Input({ value, placeholder = '입력하세요', width = '860px', onChange }: TInputProps) {
-  return <S.InputWrapper value={value} placeholder={placeholder} width={width} onChange={onChange} />;
-}
+const Input = React.forwardRef<HTMLInputElement, TInput>(({ placeholder, type, isValid, autoComplete, errorMessage, touched, valid, top, ...rest }, ref) => {
+  const [passwordType, setPasswordType] = useState('password');
+
+  if (type === 'normal') {
+    return <S.NormalInputWrapper placeholder={placeholder} ref={ref} {...rest} />;
+  }
+  return (
+    <S.Container>
+      <S.InputWrapper>
+        <S.Input
+          placeholder={placeholder}
+          type={type === 'password' ? passwordType : type}
+          $isValid={isValid}
+          autoComplete={type === 'password' ? (passwordType === 'text' ? 'current-password' : 'new-password') : autoComplete}
+          ref={ref}
+          {...rest}
+        />
+        {type === 'password' && (
+          <S.Eyes onClick={() => setPasswordType((prevType) => (prevType === 'password' ? 'text' : 'password'))} $active={passwordType === 'text'}>
+            <Eyes />
+          </S.Eyes>
+        )}
+      </S.InputWrapper>
+
+      {errorMessage && touched && top && (
+        <S.MessageWrapper2>
+          <ValidataionMessage message={errorMessage} isError={!valid} />
+        </S.MessageWrapper2>
+      )}
+      {errorMessage && touched && top === false && (
+        <S.MessageWrapper>
+          <ValidataionMessage message={errorMessage} isError={!valid} />
+        </S.MessageWrapper>
+      )}
+    </S.Container>
+  );
+});
+export default Input;

--- a/src/components/common/input/validationMessage.style.ts
+++ b/src/components/common/input/validationMessage.style.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  ${({ theme }) => theme.align.row_space_between}
+  svg {
+    width: 18px;
+    height: 18px;
+  }
+  gap: 4px;
+`;
+
+const TrueMessage = styled.div`
+  color: ${({ theme }) => theme.colors.success.success_500};
+  font-size: 14px;
+`;
+const ErrorMessage = styled.div`
+  color: ${({ theme }) => theme.colors.error.error_400};
+  font-size: 14px;
+`;
+export { Container, ErrorMessage, TrueMessage };

--- a/src/components/common/input/validationMessage.tsx
+++ b/src/components/common/input/validationMessage.tsx
@@ -1,0 +1,27 @@
+import * as S from '@/components/auth/validationMessage/validationMessage.style';
+
+import Valid from '@/assets/icons/check_circle.svg?react';
+import Wrong from '@/assets/icons/wrong.svg?react';
+
+type TValidationMessage = {
+  message: string;
+  isError: boolean | undefined;
+};
+export default function ValidataionMessage({ message, isError }: TValidationMessage) {
+  return (
+    <>
+      {isError === true && (
+        <S.Container>
+          <Wrong />
+          <S.ErrorMessage>{message}</S.ErrorMessage>
+        </S.Container>
+      )}
+      {isError === false && (
+        <S.Container>
+          <Valid />
+          <S.TrueMessage>{message}</S.TrueMessage>
+        </S.Container>
+      )}
+    </>
+  );
+}

--- a/src/pages/scenario/scenario.tsx
+++ b/src/pages/scenario/scenario.tsx
@@ -5,7 +5,7 @@ import * as S from '@/pages/scenario/scenario.style';
 export default function ScenarioPage() {
   return (
     <S.Container>
-      <Input />
+      <Input type="normal" placeholder="ㅎㅇ" />
     </S.Container>
   );
 }


### PR DESCRIPTION
## 🚨 관련 이슈
[//]: # (작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다.)
#53 
## ✨ 변경사항
[//]: # (어떤 변경사항이 있었나요? 체크해주세요 !)
- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
[//]: # (작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다.)
- 기존의 공용 input과 authInput을 둘 다 사용할 수 있게 변경했습니다.

## 😅 미완성 작업 
[//]: # (없다면 N/A)

## 📢 논의 사항 및 참고 사항 
[//]: # (리뷰어가 알면 좋은 내용을 작성해주세요.)
-기존의 공용 컴포넌트 처럼 사용하려면 type = 'normal'로 지정하시면 됩니다
-모달에서는 테스트 안 해봐서 NormalInput 부분은 수정될 수도 있습니다..

