### PR TITLE
✨ [Feature] 대시보드 에러박스 크기 수정

### DIFF
--- a/src/components/dashboard/projectInfoBox/projectInfoBox.style.ts
+++ b/src/components/dashboard/projectInfoBox/projectInfoBox.style.ts
@@ -4,12 +4,11 @@ const Container = styled.div`
   border-radius: 12.8px;
   border: 0.8px solid rgba(32, 75, 153, 0.2);
   background: linear-gradient(76deg, #001945 0%, #000714 100.13%);
-  padding: 14px;
+  padding: 10px 14px;
   width: 100%;
-  //width: 260px;
   display: flex;
   flex-direction: column;
-  gap: 30px;
+  gap: 25px;
 `;
 
 const LabelWrapper = styled.div`

--- a/src/components/dashboard/projectInfoBox/projectInfoBox.style.ts
+++ b/src/components/dashboard/projectInfoBox/projectInfoBox.style.ts
@@ -5,7 +5,8 @@ const Container = styled.div`
   border: 0.8px solid rgba(32, 75, 153, 0.2);
   background: linear-gradient(76deg, #001945 0%, #000714 100.13%);
   padding: 14px;
-  width: 260px;
+  width: 100%;
+  //width: 260px;
   display: flex;
   flex-direction: column;
   gap: 30px;

--- a/src/components/dashboard/projectStatistics/projectStatistics.style.ts
+++ b/src/components/dashboard/projectStatistics/projectStatistics.style.ts
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import { media } from '@/styles/media';
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -12,9 +14,18 @@ const ProfileBox = styled.div`
 `;
 
 const InfoWrapper = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
   gap: 20px;
-  flex-wrap: wrap;
+  width: 100%;
+
+  @media (max-width: 1260px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  ${media.phone`
+      grid-template-columns: repeat(1, 1fr);
+   `}
 `;
 
 const ProjectTitleBox = styled.div`

--- a/src/pages/dashboard/dashboard.style.ts
+++ b/src/pages/dashboard/dashboard.style.ts
@@ -4,14 +4,14 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 30px;
+  gap: 5%;
   width: 100%;
   height: 100%;
-  padding: 0 60px;
+  padding: 60px 60px;
 
-  @media (max-width: 1260px) {
-    padding: 60px 60px;
-  }
+  //@media (max-width: 1260px) {
+  //  padding: 60px 60px;
+  //}
 `;
 
 const TableWrapper = styled.div`

--- a/src/pages/dashboard/dashboard.style.ts
+++ b/src/pages/dashboard/dashboard.style.ts
@@ -8,6 +8,10 @@ const Container = styled.div`
   width: 100%;
   height: 100%;
   padding: 0 60px;
+
+  @media (max-width: 1260px) {
+    padding: 60px 60px;
+  }
 `;
 
 const TableWrapper = styled.div`


### PR DESCRIPTION
## 🚨 관련 이슈
[//]: # (작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다.)

#144 

## ✨ 변경사항
[//]: # (어떤 변경사항이 있었나요? 체크해주세요 !)
- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
[//]: # (작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다.)
- 대시보드 에러박스 크기 수정 (노션 참고)
<img width="1624" alt="스크린샷 2025-01-29 22 18 04" src="https://github.com/user-attachments/assets/bbaea671-e054-4a0b-b3a3-904b4e92bf2c" />

제 생각엔 현재 13인치는 아래와 같이 보이고 스크롤이 생길 것 같습니다.
<img width="1387" alt="스크린샷 2025-01-29 22 20 43" src="https://github.com/user-attachments/assets/7aac6d9c-f1e3-4faa-94cd-53bf520ae690" />

추후 표를 5개로 데이터를 줄일지 논의해보고 5개 또는 그 이하로 줄일 경우 13인치도 스크롤이 생기지 않을 것 같습니다.

## 😅 미완성 작업 
[//]: # (없다면 N/A)
N/A

## 📢 논의 사항 및 참고 사항 
[//]: # (리뷰어가 알면 좋은 내용을 작성해주세요.)

맥북 13에서 확인 후 정상적으로 보일 경우 머지 부탁드립니다 