### PR TITLE
[Feature/#162] 다른 사람의 mypage 조회 api 연결 및 라우팅 수정

### DIFF
--- a/src/apis/userInfo/userInfo.ts
+++ b/src/apis/userInfo/userInfo.ts
@@ -1,0 +1,15 @@
+import type { TGetUserInfoResponse, TGetUserProjectsResponse, TGetUserProjectsValues } from '@/types/userController/userController';
+
+import { axiosInstance } from '../axiosInstance';
+
+const getOtherUserInfo = async (userId: string): Promise<TGetUserInfoResponse> => {
+  const { data } = await axiosInstance.get(`/api/v0/users/${userId}`);
+  return data;
+};
+
+const getOtherUserProjectList = async ({ page, userId }: TGetUserProjectsValues): Promise<TGetUserProjectsResponse> => {
+  const { data } = await axiosInstance.get(`/api/v0/users/projects/${userId}?page=${page}`);
+  return data;
+};
+
+export { getOtherUserInfo, getOtherUserProjectList };

--- a/src/components/mypage/myProfile/myProfile.tsx
+++ b/src/components/mypage/myProfile/myProfile.tsx
@@ -25,7 +25,10 @@ import Done from '@/assets/icons/done.svg?react';
 import Edit from '@/assets/icons/edit.svg?react';
 import ProfileEdit from '@/assets/icons/profileEdit.svg?react';
 
-export default function MyProfile() {
+type TProjectListProps = {
+  setProjectNum: React.Dispatch<React.SetStateAction<number>>;
+};
+export default function MyProfile({ setProjectNum }: TProjectListProps) {
   const { useImageToUploadPresignedUrl, useGetPresignedUrl } = useImage();
   const { usePatchUserInfo, useGetUserInfo } = useUserInfo();
 
@@ -162,6 +165,7 @@ export default function MyProfile() {
 
   useEffect(() => {
     if (userData) {
+      setProjectNum(userData.result.projectCnt);
       setValue('nickname', userData.result.nickname);
       setValue('profileImage', userData.result.profileImage);
       setValue('bannerImage', userData.result.bannerImage);

--- a/src/components/userInfo/otherUserProjectList/otherUserProjectList.style.ts
+++ b/src/components/userInfo/otherUserProjectList/otherUserProjectList.style.ts
@@ -1,0 +1,104 @@
+import styled from 'styled-components';
+
+const ProjectList = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  justify-content: center;
+  background: #d9e6ff1a;
+  margin-left: 20px;
+  padding: 20px;
+  border-radius: 12.8px;
+  gap: 10px;
+  height: 283px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  position: relative;
+
+  @media (max-width: 1138px) {
+    height: 310px;
+  }
+  @media (max-width: 1129px) {
+    height: 340px;
+  }
+  @media (max-width: 1088px) {
+    flex-direction: column;
+    height: 380px;
+    overflow-x: hidden;
+  }
+  @media (max-width: 1024px) {
+    height: 340px;
+  }
+  @media (max-width: 934px) {
+    width: 100%;
+    height: 320px;
+    margin: 0;
+  }
+  @media (max-width: 914px) {
+    width: 100%;
+    height: 360px;
+    margin: 0;
+  }
+  @media (max-width: 870px) {
+    width: 100%;
+    height: 380px;
+    margin: 0;
+  }
+`;
+
+const Table = styled.table`
+  width: 100%;
+  table-layout: auto;
+  overflow-y: hidden;
+  .blank {
+    min-width: 2rem;
+  }
+
+  @media (max-width: 1050px) {
+    max-height: 80%;
+    overflow-x: scroll;
+  }
+`;
+
+const TableWrapper = styled.div`
+  overflow-x: auto;
+  flex: 1;
+  overflow-y: hidden;
+`;
+
+const TH = styled.th`
+  ${({ theme }) => theme.text.medium_18};
+  text-align: left;
+  height: 26px;
+  padding-bottom: 16px;
+  color: ${({ theme }) => theme.colors.primary.pri_50};
+
+  @media (max-width: 1138px), (max-width: 1050px) {
+    text-align: center;
+    padding: 10px;
+  }
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 5px;
+
+  @media (max-width: 1087px) {
+    justify-content: center;
+    gap: 30px;
+    width: 100%;
+  }
+`;
+
+const Button = styled.div<{ $disable: boolean }>`
+  &:hover {
+    cursor: ${(props) => (props.$disable ? 'default' : 'pointer')};
+  }
+  svg {
+    width: 19.2px;
+    height: 19.2px;
+  }
+`;
+
+export { Button, Buttons, ProjectList, Table, TableWrapper, TH };

--- a/src/components/userInfo/otherUserProjectList/otherUserProjectList.tsx
+++ b/src/components/userInfo/otherUserProjectList/otherUserProjectList.tsx
@@ -3,20 +3,20 @@ import { useNavigate } from 'react-router-dom';
 
 import type { TUserProjectListResponse } from '@/types/userController/userController';
 
-import useProjects from '@/hooks/project/useProject';
+import useOtherUserInfo from '@/hooks/userInfo/useOtherUserInfo';
 
 import Project from '@/components/mypage/project/project';
 
-import * as S from './projectList.style';
+import * as S from './otherUserProjectList.style.ts';
 
 import ArrowLeft from '@/assets/icons/arrow_left_noColor.svg?react';
 import ArrowRight from '@/assets/icons/arrow_right_noColor.svg?react';
 
-export default function ProjectList() {
+export default function OtherUserProjectList({ userId }: { userId: string }) {
   const navigate = useNavigate();
   const [currentPage, setCurrentPage] = useState(0);
-  const { useGetMypageProjects } = useProjects(currentPage);
-  const { data } = useGetMypageProjects;
+  const { useGetOtherUserProjects } = useOtherUserInfo({ userId, currentPage });
+  const { data } = useGetOtherUserProjects;
 
   const projectsData = data?.result.userProjectList;
 

--- a/src/components/userInfo/userProfile/userProfile.style.ts
+++ b/src/components/userInfo/userProfile/userProfile.style.ts
@@ -1,0 +1,361 @@
+import styled from 'styled-components';
+
+type TBannerImg = {
+  url?: string;
+};
+
+const Container = styled.div`
+  display: flex;
+  width: 100%;
+  justify-self: center;
+  height: 100vh;
+  flex-direction: column;
+  padding: 30px;
+  max-width: 1200px;
+  gap: 20px;
+  overflow-y: scroll;
+`;
+const Title = styled.div`
+  width: 79px;
+  height: 29px;
+  top: 80px;
+  left: 352px;
+  gap: 0px;
+  opacity: 0px;
+  font-family: Pretendard;
+  font-size: 19.2px;
+  font-weight: 500;
+  line-height: 28.8px;
+  letter-spacing: 0.02em;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+`;
+
+const LoadingOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white;
+  font-size: 20px;
+  font-weight: bold;
+`;
+const ProfileWrapper = styled.div`
+  display: flex;
+  position: relative;
+  height: 45%;
+  border-radius: 12.8px;
+  width: 100%;
+  align-items: end;
+  min-height: 155px;
+  justify-content: space-between;
+`;
+
+const Profile = styled.div`
+  display: flex;
+  position: absolute;
+  bottom: 10px;
+  left: 0px;
+  width: 100%;
+  gap: 20px;
+  z-index: 1;
+  height: 133px;
+  align-items: center;
+  .hover {
+    &:hover {
+      cursor: pointer;
+    }
+  }
+`;
+
+const BannerImg = styled.div<TBannerImg>`
+  border-radius: 12.8px;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.2) !important;
+  background: ${({ url }) =>
+    url
+      ? `linear-gradient(0deg, rgba(0, 7, 20, 0.8) 0%, rgba(0, 7, 20, 0) 100%), url(${url})`
+      : 'linear-gradient(rgba(0, 7, 20, 0) 0%, rgba(0, 7, 20, 0.9) 100%)'};
+  background-size: cover;
+  background-position: center;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const InputValidateWrapper = styled.div`
+  position: relative;
+  display: flex;
+`;
+
+const UserInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  bottom: 10px;
+  padding: 16px 0;
+  gap: 6.4px;
+  max-width: 60%;
+  span {
+    color: ${({ theme }) => theme.colors.primary.pri_50};
+    font-size: 38.4px;
+    font-weight: 700;
+    line-height: 57.6px;
+    letter-spacing: 0.02em;
+    text-align: left;
+    text-underline-position: from-font;
+    text-decoration-skip-ink: none;
+  }
+`;
+
+const Account = styled.div`
+  display: flex;
+  font-size: 19.2px;
+  font-weight: 500;
+  font-family: Pretendard;
+  line-height: 28.8px;
+  letter-spacing: 0.02em;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+`;
+
+const PlusWrapper = styled.button`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  width: 26px;
+  height: 26px;
+  background-color: rgba(217, 230, 255, 0.2);
+  border-radius: 79.2px;
+  border: none;
+  svg {
+    width: 10.97px;
+    height: 10.97px;
+  }
+  @media (max-width: 625px) {
+    display: none;
+  }
+`;
+
+const AccoutWrapper = styled.div`
+  display: flex;
+  height: 26px;
+  width: 100%;
+  align-items: center;
+  .socialLogoWrapper {
+    @media (max-width: 690px) {
+      display: none;
+    }
+  }
+`;
+
+const ProjectNum = styled.div`
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(76.11deg, #001945 0%, #000714 100.13%);
+  padding: 32px 24px;
+  gap: 16.8px;
+  border-radius: 12.8px;
+  max-width: 184px;
+  height: 210px;
+  svg {
+    width: 51.2px;
+    height: 51.2px;
+  }
+  .ProjectNumber {
+    font-size: 32px;
+    font-weight: 700;
+    color: #ffffff;
+  }
+  span {
+    font-size: 14.4px;
+  }
+`;
+
+const Projects = styled.div`
+  display: flex;
+  flex: 1;
+  gap: 20px;
+`;
+
+const ProjectList = styled.div`
+  display: flex;
+  background: #d9e6ff1a;
+  flex: 1;
+  margin-left: 20px;
+  padding: 20px;
+  height: auto; /* 자동으로 크기 조정 */
+  border-radius: 12.8px;
+  overflow-x: scroll;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  height: auto;
+  table-layout: auto;
+  .right {
+    padding-right: 2rem;
+  }
+`;
+
+const ButtonWrapper = styled.div`
+  z-index: 2;
+  align-self: end;
+  padding: 5px 0;
+  @media (max-width: 560px) {
+    display: none;
+  }
+`;
+
+const TH = styled.th`
+  ${({ theme }) => theme.text.medium_18}
+  text-align: left;
+  height: 26px;
+  padding-bottom: 16px;
+  color: ${({ theme }) => theme.colors.primary.pri_50};
+`;
+
+const TD = styled.td`
+  ${({ theme }) => theme.text.medium_14}
+  height: 26px;
+  color: ${({ theme }) => theme.colors.primary.pri_50};
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  gap: 8px;
+  flex: none;
+  svg {
+    width: 19.2px;
+    height: 19.2px;
+  }
+`;
+
+const ProjectNameTD = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  ${({ theme }) => theme.text.medium_14}
+  .ProfileWrapper {
+    width: 19.2px;
+    height: 19.2px;
+  }
+`;
+
+const TR = styled.tr`
+  height: 26px;
+`;
+
+const TBody = styled.tbody`
+  height: auto;
+  gap: 8px;
+`;
+
+const ProfileImg = styled.div`
+  min-width: 112px;
+  min-height: 112px;
+  max-width: 112px;
+  max-height: 112px;
+  border-radius: 100%;
+  background-color: #505050;
+  ${({ theme }) => theme.align.row_center};
+  position: relative;
+  z-index: 1;
+
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+`;
+const MessageWrapper = styled.div`
+  display: flex;
+  position: absolute;
+  top: -24px;
+  left: 0;
+`;
+
+const ProfileEditBtn = styled.button`
+  background-color: ${({ theme }) => theme.colors.point.point_2};
+  border-radius: 100%;
+  ${({ theme }) => theme.align.row_center};
+  position: absolute;
+  width: 44.8px;
+  height: 44.8px;
+  top: 67.2px;
+  left: 67.2px;
+  padding: 9.6px 8.8px 9.6px 10.4px;
+  gap: 0px;
+  border-radius: 79.2px;
+  opacity: 0px;
+
+  border: none;
+  z-index: 2;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const Container2 = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  padding: 20px;
+  height: 152px;
+`;
+
+const ProfileUserInfo = styled.div`
+  display: flex;
+  gap: 15px;
+  width: 100%;
+`;
+
+const SocialLogoWrapper = styled.div`
+  display: flex;
+  background-color: rgba(22, 24, 28, 1);
+  border: 0.8px solid rgba(8, 38, 89, 1);
+  border-radius: 6.4px;
+  padding: 8px;
+  position: absolute;
+  bottom: -55px;
+  left: 0;
+`;
+
+export {
+  Account,
+  AccoutWrapper,
+  BannerImg,
+  Buttons,
+  ButtonWrapper,
+  Container,
+  Container2,
+  InputValidateWrapper,
+  LoadingOverlay,
+  MessageWrapper,
+  PlusWrapper,
+  Profile,
+  ProfileEditBtn,
+  ProfileImg,
+  ProfileUserInfo,
+  ProfileWrapper,
+  ProjectList,
+  ProjectNameTD,
+  ProjectNum,
+  Projects,
+  SocialLogoWrapper,
+  Table,
+  TBody,
+  TD,
+  TH,
+  Title,
+  TR,
+  UserInfo,
+};

--- a/src/components/userInfo/userProfile/userProfile.tsx
+++ b/src/components/userInfo/userProfile/userProfile.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+
+import useOtherUserInfo from '@/hooks/userInfo/useOtherUserInfo';
+
+import Profile from '@/components/common/profile/profile';
+
+import * as S from './userProfile.style';
+
+type TMyprofile = {
+  setUsername: React.Dispatch<React.SetStateAction<string>>;
+  setProjectNum: React.Dispatch<React.SetStateAction<number>>;
+  userId: string;
+};
+
+export default function UserProfile({ setUsername, setProjectNum, userId }: TMyprofile) {
+  const { useGetOtherUserInfo } = useOtherUserInfo({ userId: userId || '', currentPage: 0 });
+  const { data: userData } = useGetOtherUserInfo;
+
+  useEffect(() => {
+    if (userData) {
+      setProjectNum(userData.result.projectCnt);
+      setUsername(userData?.result.nickname);
+    }
+  }, [userData]);
+
+  return (
+    <>
+      <S.ProfileWrapper>
+        <S.BannerImg url={userData?.result.bannerImage} />
+        <S.Profile>
+          <S.Container2>
+            <S.ProfileUserInfo>
+              <S.ProfileImg>
+                <Profile profileImg={userData?.result.profileImage} />
+              </S.ProfileImg>
+              <S.UserInfo>
+                <span>{userData?.result.nickname}</span>
+                <S.AccoutWrapper>
+                  <S.Account>{userData?.result.email}</S.Account>
+                </S.AccoutWrapper>
+              </S.UserInfo>
+            </S.ProfileUserInfo>
+          </S.Container2>
+        </S.Profile>
+      </S.ProfileWrapper>
+    </>
+  );
+}

--- a/src/constants/querykeys/queryKeys.ts
+++ b/src/constants/querykeys/queryKeys.ts
@@ -12,8 +12,10 @@ export const QUERY_KEYS = {
   PROJECT_MEMBER: ({ projectId }: TProjectInfo) => ['getProjectMember', projectId],
   PROJECT_MEMBER_EMAIL: ({ projectId }: TProjectInfo) => ['getMemberEmail', projectId],
   GET_USER_PROJECT_LIST: (page: number | null) => ['getUserProjectList', page],
+  GET_OTHER_USER_PROJECT_LIST: ({ page, userId }: { page: number; userId: string }) => ['getUserProjectList', page, userId],
   GET_USER_INFO: ['getUserInfo'],
   GET_USER_SIDEBAR_INFO: ['getUserSidebarInfo'],
+  GET_OTHER_USER_INFO: (userId: string) => ['getUserInfo', userId],
   DASHBOARD: {
     ERROR: (testId: number) => ['ERROR', testId],
     TEST: {

--- a/src/hooks/mypage/useUserInfo.ts
+++ b/src/hooks/mypage/useUserInfo.ts
@@ -14,5 +14,6 @@ export default function useUserInfo() {
       });
     },
   });
+
   return { useGetUserInfo, usePatchUserInfo };
 }

--- a/src/hooks/userInfo/useOtherUserInfo.ts
+++ b/src/hooks/userInfo/useOtherUserInfo.ts
@@ -1,0 +1,13 @@
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+
+import { getOtherUserInfo, getOtherUserProjectList } from '@/apis/userInfo/userInfo';
+
+import { useCoreQuery } from '../common/customQuery';
+
+export default function useOtherUserInfo({ userId, currentPage }: { userId: string; currentPage: number }) {
+  const useGetOtherUserInfo = useCoreQuery(QUERY_KEYS.GET_OTHER_USER_INFO(userId), () => getOtherUserInfo(userId));
+  const useGetOtherUserProjects = useCoreQuery(QUERY_KEYS.GET_OTHER_USER_PROJECT_LIST({ userId, page: currentPage }), () =>
+    getOtherUserProjectList({ page: currentPage, userId }),
+  );
+  return { useGetOtherUserInfo, useGetOtherUserProjects };
+}

--- a/src/pages/mypage/mypage.tsx
+++ b/src/pages/mypage/mypage.tsx
@@ -11,10 +11,10 @@ export default function MyPage() {
   return (
     <S.Container>
       <S.Title>My Page</S.Title>
-      <MyProfile />
+      <MyProfile setProjectNum={setProjectNum} />
       <S.Projects>
         <ProjectNum projectNum={projectNum} />
-        <ProjectList setProjectNum={setProjectNum} />
+        <ProjectList />
       </S.Projects>
     </S.Container>
   );

--- a/src/pages/userInfo/userInfo.style.ts
+++ b/src/pages/userInfo/userInfo.style.ts
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  width: calc(100vw - 300px);
+  width: 100%;
+  justify-self: center;
+  height: 100vh;
+  flex-direction: column;
+  padding: 30px;
+  max-width: 1200px;
+  gap: 20px;
+  overflow-y: scroll;
+  overflow-x: hidden;
+`;
+const Title = styled.div`
+  height: 29px;
+  top: 80px;
+  left: 352px;
+  gap: 0px;
+  opacity: 0px;
+  font-family: Pretendard;
+  font-size: 19.2px;
+  font-weight: 500;
+  line-height: 28.8px;
+  letter-spacing: 0.02em;
+  text-align: left;
+  text-underline-position: from-font;
+  text-decoration-skip-ink: none;
+`;
+
+const Projects = styled.div`
+  display: flex;
+  flex: 1;
+  gap: 20px;
+  @media (max-width: 847px) {
+    flex-direction: column;
+    align-items: center;
+  }
+`;
+
+export { Container, Projects, Title };

--- a/src/pages/userInfo/userInfo.tsx
+++ b/src/pages/userInfo/userInfo.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import ProjectNum from '@/components/mypage/projectNum/projectNum';
+import OtherUserProjectList from '@/components/userInfo/otherUserProjectList/otherUserProjectList';
+import UserProfile from '@/components/userInfo/userProfile/userProfile';
+
+import * as S from './userInfo.style';
+
+export default function UserInfo() {
+  const [projectNum, setProjectNum] = useState(0);
+  const [userName, setUsername] = useState('');
+  const { userId } = useParams();
+  return (
+    <S.Container>
+      <S.Title>{userName}'s My Page</S.Title>
+      <UserProfile setUsername={setUsername} setProjectNum={setProjectNum} userId={userId || ''} />
+      <S.Projects>
+        <ProjectNum projectNum={projectNum} />
+        <OtherUserProjectList userId={userId || ''} />
+      </S.Projects>
+    </S.Container>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,6 +13,7 @@ import MyPage from '@/pages/mypage/mypage';
 import ScenarioPage from '@/pages/scenario/scenario';
 import ScenarioActPage from '@/pages/scenarioAct/scenarioAct';
 import SignupPage from '@/pages/signup/signup';
+import UserInfo from '@/pages/userInfo/userInfo';
 import UserSetting from '@/pages/userSetting/userSetting';
 
 export const router = createBrowserRouter([
@@ -24,6 +25,11 @@ export const router = createBrowserRouter([
         <ModalProvider />
       </>
     ),
+  },
+  {
+    path: '/userInfo/:userId',
+    element: <MainLayout />,
+    children: [{ index: true, element: <UserInfo /> }],
   },
   {
     path: '/mypage',

--- a/src/types/userController/userController.ts
+++ b/src/types/userController/userController.ts
@@ -8,7 +8,9 @@ export type TGetUserInfoResponse = TCommonResponse<{
   email: string;
   profileImage: string;
   bannerImage: string;
-  account: SOCIAL[] | undefined;
+  account?: SOCIAL[] | undefined;
+  projectCnt: number;
+  isUser?: boolean;
 }>;
 
 export type TPatchUserInfoValues = {
@@ -28,6 +30,7 @@ export type TPatchUserInfoResponse = TCommonResponse<{
 
 export type TGetUserProjectsValues = {
   page?: number;
+  userId?: string;
 };
 
 export type TUserProjectListResponse = {


### PR DESCRIPTION
## 🚨 관련 이슈
#162 

## ✨ 변경사항
[//]: # (어떤 변경사항이 있었나요? 체크해주세요 !)
- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
[//]: # (작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다.)
- /userInfo/:userId 라우팅 새로 추가

## 😅 미완성 작업 
[//]: # (없다면 N/A)
N/A

## 📢 논의 사항 및 참고 사항 
- 본인의 userInfo로 들어가도 현재 mypage처럼 이용하지는 못합니다. (닉네임, 프로필 사진, 배너사진 수정 등)
- mypage랑 userInfo를 나눈 이유는 현재로선 userInfo로 통합시 마이페이지에서 소셜 계정 추가 후 userInfo/:userId로 리다이렉트를 시키지 못합니다 (만일 이렇게 하고싶다면 유저아이디를 전역관리 혹은 queryParam등으로 추가적으로 관리해야함. 현재 어떤 정보도 전역관리 하고있지 않습니다.)
- userInfo로 본인이 접속 시 navigate 시키지 않은 이유는 우선 본인의 userInfo로 접속할 가능성이 낮다고 판단하였고, 만일 이 경우도 연결하려면 userId를 전역관리 혹은 api response로 추가적으로 관리해야하는데 우선 하지 않았습니다.
- 추후 수정될 여지는 많습니다.... 
