### PR TITLE
♻️ [Refactor] 대시보드에서 사용하지 않는 api 요청 방지

### DIFF
--- a/src/components/common/loading/loading.style.ts
+++ b/src/components/common/loading/loading.style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 const Container = styled.div`
   width: 100%;
+  height: calc(100% - 66px);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/common/projectHeader/projectHeader.tsx
+++ b/src/components/common/projectHeader/projectHeader.tsx
@@ -3,7 +3,7 @@ import { useLocation, useParams } from 'react-router-dom';
 
 import { DEVICE, STACK } from '@/enums/enums';
 
-import { useProjectInfo } from '@/hooks/projectInfo/useProjectInfo';
+import useProjectExtractInfo from '@/hooks/projectInfo/useProjectExtractInfo';
 
 import ProjectTitle from '@/components/common/projectTitle/projectTitle';
 
@@ -18,8 +18,7 @@ import { openModal } from '@/slices/modalSlice';
 
 export default function ProjectHeader() {
   const { projectId } = useParams();
-  const { useProjectExtractInfo } = useProjectInfo({ projectId: Number(projectId) });
-  const { data, isLoading } = useProjectExtractInfo;
+  const { data, isLoading } = useProjectExtractInfo(Number(projectId));
   const location = useLocation();
   const isInformationPage = location.pathname.startsWith('/project/information/');
 

--- a/src/components/dashboard/selectBox/selectBox.style.ts
+++ b/src/components/dashboard/selectBox/selectBox.style.ts
@@ -12,9 +12,15 @@ const Container = styled.ul`
   border: 0.8px solid #082659;
   background: #16181c;
 
-  max-height: 300px;
+  max-height: 280px;
   overflow-y: auto;
   z-index: 10;
+
+  &::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+    display: none;
+  }
 
   li {
     ${({ theme }) => theme.text.medium_14};

--- a/src/components/dashboard/table/pageNameHeader.tsx
+++ b/src/components/dashboard/table/pageNameHeader.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { useProjectId } from '@/hooks/common/useProjectId.ts';
 import type { TFilter } from '@/hooks/dashborad/useTableFilter.ts';
-import { useProjectInfo } from '@/hooks/projectInfo/useProjectInfo';
+import useGetPageSummary from '@/hooks/projectInfo/useGetPageSummary';
 
 import SelectBox from '@/components/dashboard/selectBox/selectBox';
 import * as S from '@/components/dashboard/table/table.style';
@@ -16,8 +16,7 @@ interface IProps {
 export default function PageNameHeader({ setFilters }: IProps) {
   const [isClicked, setIsClicked] = useState(false);
   const projectId = useProjectId();
-  const { useGetPageSummary } = useProjectInfo({ projectId });
-  const { data } = useGetPageSummary;
+  const { data } = useGetPageSummary(projectId);
 
   const PAGE_NAMES = ['All', ...(data?.result.pageSummaryList.map((page) => page.pageName) ?? [])];
 

--- a/src/components/projectInfo/projectSummary/projectSummary.tsx
+++ b/src/components/projectInfo/projectSummary/projectSummary.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import type { TInfoDTO } from '@/types/projectInfo/projectInfo';
 
 import { useDispatch } from '@/hooks/common/useCustomRedux.ts';
+import useGetPageSummary from '@/hooks/projectInfo/useGetPageSummary.ts';
 import { useProjectInfo } from '@/hooks/projectInfo/useProjectInfo';
 
 import Button from '@/components/common/button/button';
@@ -20,8 +21,8 @@ export default function ProjectInfoPage({ result }: TInfoDTO) {
   const modalDispatch = useDispatch();
   const [isStructureVisible, setIsStructureVisible] = useState(true);
   const [selectedPage, setSelectedPage] = useState(0);
-  const { useGetPageSummary, useGetCharacter } = useProjectInfo({ projectId: Number(result?.projectId) });
-  const { data: summaryList } = useGetPageSummary;
+  const { useGetCharacter } = useProjectInfo({ projectId: Number(result?.projectId) });
+  const { data: summaryList } = useGetPageSummary(Number(result?.projectId));
   const { data: characterList } = useGetCharacter;
   const summary = summaryList?.result.pageSummaryList;
   const character = characterList?.result.detailCharacters;

--- a/src/hooks/projectInfo/useGetPageSummary.ts
+++ b/src/hooks/projectInfo/useGetPageSummary.ts
@@ -1,0 +1,9 @@
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+
+import { getPageSummaryList } from '@/apis/projectInfo/projectInfo';
+
+import { useCoreQuery } from '@/hooks/common/customQuery';
+
+export default function useGetPageSummary(projectId: number) {
+  return useCoreQuery(QUERY_KEYS.PAGE_SUMMARY({ projectId }), () => getPageSummaryList({ projectId }), { enabled: !!projectId });
+}

--- a/src/hooks/projectInfo/useProjectExtractInfo.ts
+++ b/src/hooks/projectInfo/useProjectExtractInfo.ts
@@ -1,0 +1,11 @@
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys.ts';
+
+import { getProjectInfo } from '@/apis/projectInfo/projectInfo.ts';
+
+import { useCoreQuery } from '@/hooks/common/customQuery.ts';
+
+export default function useProjectExtractInfo(projectId: number) {
+  return useCoreQuery(QUERY_KEYS.PROJECT_INFO({ projectId }), () => getProjectInfo({ projectId }), {
+    enabled: !!projectId,
+  });
+}

--- a/src/hooks/projectInfo/useProjectInfo.ts
+++ b/src/hooks/projectInfo/useProjectInfo.ts
@@ -1,30 +1,17 @@
 import type { TProjectInfo } from '@/types/projectInfo/projectInfo';
 import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
 
-import {
-  deleteProject,
-  editIntroduce,
-  getCharacter,
-  getMemberEmail,
-  getPageSummaryList,
-  getPath,
-  getProjectInfo,
-  getProjectMember,
-} from '@/apis/projectInfo/projectInfo';
+import { deleteProject, editIntroduce, getCharacter, getMemberEmail, getPath, getProjectMember } from '@/apis/projectInfo/projectInfo';
 
 import { useCoreMutation, useCoreQuery } from '../common/customQuery';
 
 export function useProjectInfo({ projectId }: TProjectInfo) {
-  const useProjectExtractInfo = useCoreQuery(QUERY_KEYS.PROJECT_INFO({ projectId }), () => getProjectInfo({ projectId }), {
-    enabled: !!projectId,
-    staleTime: 60 * 5 * 1000,
-  });
   const useEditIntroduce = useCoreMutation(editIntroduce, {});
   const useGetProjectMember = useCoreQuery(QUERY_KEYS.PROJECT_MEMBER({ projectId }), () => getProjectMember({ projectId }), { enabled: !!projectId });
   const useGetMemberEmail = useCoreQuery(QUERY_KEYS.PROJECT_MEMBER_EMAIL({ projectId }), () => getMemberEmail({ projectId }), { enabled: !!projectId });
-  const useGetPageSummary = useCoreQuery(QUERY_KEYS.PAGE_SUMMARY({ projectId }), () => getPageSummaryList({ projectId }), { enabled: !!projectId });
   const useGetCharacter = useCoreQuery(QUERY_KEYS.CHARACTER({ projectId }), () => getCharacter({ projectId }), { enabled: !!projectId });
   const useGetPath = useCoreQuery(QUERY_KEYS.PATH({ projectId }), () => getPath({ projectId }), { enabled: !!projectId });
   const useDeleteProject = useCoreMutation(deleteProject);
-  return { useProjectExtractInfo, useDeleteProject, useEditIntroduce, useGetProjectMember, useGetMemberEmail, useGetPageSummary, useGetCharacter, useGetPath };
+
+  return { useDeleteProject, useEditIntroduce, useGetProjectMember, useGetMemberEmail, useGetCharacter, useGetPath };
 }

--- a/src/pages/addProject/addProject.style.ts
+++ b/src/pages/addProject/addProject.style.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { media } from '@/styles/media';
 
 export const Container = styled.div`
-  height: 100vh;
+  height: calc(100% - 66px);
   width: 100%;
   min-width: 500px;
   ${({ theme }) => theme.align.column_center};

--- a/src/pages/addProject/addProject.tsx
+++ b/src/pages/addProject/addProject.tsx
@@ -11,7 +11,6 @@ import Button from '@/components/common/button/button';
 import Loading from '@/components/common/loading/loading';
 import Modal from '@/components/common/modal/modal';
 import { MODAL_TYPES } from '@/components/common/modalProvider/modalProvider';
-import ProjectProfile from '@/components/common/sidebar/projectProfile/projectProfile';
 
 import ProjectInfoPage from '../projectInfo/projectInfo';
 
@@ -24,7 +23,7 @@ export default function AddProjectPage() {
   const { projectId } = useParams();
   const { useUploadFile } = useUploadZipFile();
   const { useProjectExtractInfo } = useProjectInfo({ projectId: Number(projectId) });
-  const { data, isSuccess, isError: projectInfoError } = useProjectExtractInfo;
+  const { data, isError: projectInfoError } = useProjectExtractInfo;
   const { useGetProjectList } = useProjectList();
   const { data: projectList, isSuccess: isProjectListLoaded } = useGetProjectList;
   const navigate = useNavigate();
@@ -119,16 +118,6 @@ export default function AddProjectPage() {
     <S.Container>
       {projectList?.result.projectList[0] && (
         <>
-          {projectId && isSuccess && (
-            <S.ProfileWrapper>
-              <S.Profile>
-                <S.Wrapper>
-                  <ProjectProfile profileImg={data.result.projectImage} />
-                </S.Wrapper>
-                <S.ProfileName>{data.result.projectName}</S.ProfileName>
-              </S.Profile>
-            </S.ProfileWrapper>
-          )}
           <S.Title>Add Project File</S.Title>
           <S.Text>
             Please enter the project folder for AI to understand the project. <br />

--- a/src/pages/addProject/addProject.tsx
+++ b/src/pages/addProject/addProject.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { useProjectInfo } from '@/hooks/projectInfo/useProjectInfo';
+import useProjectExtractInfo from '@/hooks/projectInfo/useProjectExtractInfo.ts';
 import { useUploadZipFile } from '@/hooks/projectInfo/useUploadZip';
 import useProjectList from '@/hooks/sidebar/sidebar';
 
@@ -22,8 +22,7 @@ export default function AddProjectPage() {
   const dispatch = useDispatch();
   const { projectId } = useParams();
   const { useUploadFile } = useUploadZipFile();
-  const { useProjectExtractInfo } = useProjectInfo({ projectId: Number(projectId) });
-  const { data, isError: projectInfoError } = useProjectExtractInfo;
+  const { data, isError: projectInfoError } = useProjectExtractInfo(Number(projectId));
   const { useGetProjectList } = useProjectList();
   const { data: projectList, isSuccess: isProjectListLoaded } = useGetProjectList;
   const navigate = useNavigate();

--- a/src/pages/dashboard/dashboard.style.ts
+++ b/src/pages/dashboard/dashboard.style.ts
@@ -3,13 +3,16 @@ import styled from 'styled-components';
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+
   gap: 25px;
   width: 100%;
+  height: 100%;
   padding: 20px 60px 0;
 
-  //@media (max-width: 1260px) {
-  //  padding: 60px 60px;
-  //}
+  @media (min-height: 800px) {
+    margin-top: 20px;
+    gap: 50px;
+  }
 `;
 
 const TableWrapper = styled.div`


### PR DESCRIPTION
## 🚨 관련 이슈
[//]: # (작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다.)

#289 

## ✨ 변경사항
[//]: # (어떤 변경사항이 있었나요? 체크해주세요 !)
- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
[//]: # (작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다.)
- 대시보드에서 & 시나리오에서 all-emails, team-members, paths 등이 호출되는 것을 방지 

## 😅 미완성 작업 
[//]: # (없다면 N/A)
N/A

## 📢 논의 사항 및 참고 사항 
[//]: # (리뷰어가 알면 좋은 내용을 작성해주세요.)

일단, all-emails, team-members, paths 등이 호출되는 것을 확인하고 생각해보니 
대시보드에서 레이아웃에 있는 projectTitle와 제가 pageName을 가져오는 과정에서 채현님이 만드신 useProjectInfo hook에서 불러왔는데 
이렇게 되면 useProjectInfo에 있는 모든 훅들이 호출된다고합니다 (all-emails, team-members, paths 등) 
projectTitle, pageName 은 인포메이션 화면 뿐만 아니라 다른 페이지에서도 사용되야하는 부분이기 때문에 분리해야한다고 봐서 
그 부분을 분리하니 다른 부분이 호출되지 않는것을 확인할 수 있었습니다 !

만약, 이런 동일한 문제가 있다면 api 요청을 하는 부분에서 훅을 이용해 사용하고있는지 (제가 다른 부분을 다 확인해보진 못해서 일단 제 대시보드 기준으로 확인했습니다)
그 훅 안에 여러 호출들이 같이 호출되고있는 문제라면 분리하는 부분을 사용해야할 것 같습니다 !
@yeonjin719 

