### PR TITLE
[bugfix] api 요청 시 projectId가 0으로 가는 에러 해결

### DIFF
--- a/src/components/projectInfo/ChangeOwnerModal/changeOwnerModal.tsx
+++ b/src/components/projectInfo/ChangeOwnerModal/changeOwnerModal.tsx
@@ -27,7 +27,9 @@ export default function ChangeOwnerModal({ onClose, projectId = 0, userId = 0 }:
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ['getProjectMember', projectId] });
+          queryClient.invalidateQueries({ queryKey: ['getMemberEmail', projectId] });
           onClose();
+          window.location.reload();
         },
         onError: (err) => {
           setErrorMessage(err.response?.data.message || 'An error occurred.');

--- a/src/components/projectInfo/menu/menu.tsx
+++ b/src/components/projectInfo/menu/menu.tsx
@@ -12,9 +12,9 @@ import { openModal } from '@/slices/modalSlice.ts';
 export type TMenuProps = {
   children: React.ReactNode;
   userId?: number;
-  isLeader?: boolean;
-  projectId?: number;
-  email?: string;
+  isLeader: boolean;
+  projectId: number;
+  email: string;
 };
 
 export default function Menu({ children, userId, isLeader, projectId, email }: TMenuProps) {
@@ -24,6 +24,7 @@ export default function Menu({ children, userId, isLeader, projectId, email }: T
   const buttonRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
+
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(event.target as Node) && buttonRef.current && !buttonRef.current.contains(event.target as Node)) {

--- a/src/components/projectInfo/teamMember/teamMember.tsx
+++ b/src/components/projectInfo/teamMember/teamMember.tsx
@@ -22,6 +22,7 @@ export default function TeamMember({ result }: TInfoDTO) {
   const { data: members } = useGetProjectMember;
   const member = members?.result.members;
   const unAcceptedMember = members?.result.unacceptedMembers;
+
   return (
     <>
       <S.Title>Team Members</S.Title>
@@ -35,7 +36,7 @@ export default function TeamMember({ result }: TInfoDTO) {
               <S.MemberName>{a.nickname}</S.MemberName>
               {a.projectRole === 'LEADER' && <Crown />}
             </S.MemberBox>
-            <Menu userId={a.userId} isLeader={result?.isLeader} email={a.email}>
+            <Menu userId={a.userId} isLeader={result?.isLeader || false} email={a.email} projectId={Number(result?.projectId)}>
               <ArrowRight style={{ cursor: 'pointer' }} />
             </Menu>
           </S.Member>


### PR DESCRIPTION
## 🚨 관련 이슈
[//]: # (작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다.)
#311 
## ✨ 변경사항
[//]: # (어떤 변경사항이 있었나요? 체크해주세요 !)
- [x] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
[//]: # (작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다.)
- projectId가 누락되어 초기화 값인 0으로 요청이 가는 상황 발생

## 😅 미완성 작업 
[//]: # (없다면 N/A)
- [ ] 권한 변경 후 invalidatequeries를 사용하였음에도 불구하고 리더한테만 떠야하는 owner, remove 옵션이 그대로 뜸 -> 새로고침하면 제대로 뜨는 문제. 현재는 강제 새로 고침을 하여 반영 시켰는데 뭐가 원인인지는 모르겠어서 우선 급한대로 큰 문제만 해결했습니다

## 📢 논의 사항 및 참고 사항 
[//]: # (리뷰어가 알면 좋은 내용을 작성해주세요.)
