### PR TITLE
[Refactor] 로그아웃 시 캐시 지우기 및 효율성 증가 시키기

### DIFF
--- a/src/components/common/sidebar/logtoutModal/logoutModal.tsx
+++ b/src/components/common/sidebar/logtoutModal/logoutModal.tsx
@@ -1,5 +1,3 @@
-import { useNavigate } from 'react-router-dom';
-
 import useUserAuth from '@/hooks/auth/useUserAuth';
 
 import Button from '@/components/common/button/button';
@@ -11,7 +9,6 @@ type TLogoutModalProps = {
 };
 
 export default function LogoutModal({ onClose }: TLogoutModalProps) {
-  const navigate = useNavigate();
   const { useLogout } = useUserAuth();
   const { mutate: logoutMutate } = useLogout;
   const handleLogout = () => {
@@ -19,11 +16,11 @@ export default function LogoutModal({ onClose }: TLogoutModalProps) {
       {},
       {
         onSuccess: () => {
-          navigate('/', { replace: true });
+          window.location.replace('/');
           onClose();
         },
         onError: () => {
-          navigate('/', { replace: true });
+          window.location.replace('/');
           onClose();
         },
       },

--- a/src/components/common/sidebar/logtoutModal/logoutModal.tsx
+++ b/src/components/common/sidebar/logtoutModal/logoutModal.tsx
@@ -4,13 +4,15 @@ import Button from '@/components/common/button/button';
 import Modal from '@/components/common/modal/modal';
 import * as S from '@/components/common/sidebar/logtoutModal/logoutModal.style';
 
+import ModalLoading from '../../loading/modalLoading';
+
 type TLogoutModalProps = {
   onClose: () => void;
 };
 
 export default function LogoutModal({ onClose }: TLogoutModalProps) {
   const { useLogout } = useUserAuth();
-  const { mutate: logoutMutate } = useLogout;
+  const { mutate: logoutMutate, isPending } = useLogout;
   const handleLogout = () => {
     logoutMutate(
       {},
@@ -26,14 +28,16 @@ export default function LogoutModal({ onClose }: TLogoutModalProps) {
       },
     );
   };
+
   return (
     <Modal title="Are you sure you want to log out?" onClose={onClose}>
+      {isPending && <ModalLoading />}
       <S.ModalBox>
         <S.BtnWrapper>
-          <Button type="normal" color="white_square" onClick={onClose}>
+          <Button type="normal" color="white_square" onClick={onClose} disabled={isPending}>
             No
           </Button>
-          <Button type="normal" color="blue" onClick={handleLogout}>
+          <Button type="normal" color="blue" onClick={handleLogout} disabled={isPending}>
             Yes
           </Button>
         </S.BtnWrapper>

--- a/src/components/projectInfo/ChangeOwnerModal/changeOwnerModal.tsx
+++ b/src/components/projectInfo/ChangeOwnerModal/changeOwnerModal.tsx
@@ -5,6 +5,7 @@ import { useChangeOwner } from '@/hooks/projectInfo/useChangeOwner';
 
 import Button from '@/components/common/button/button';
 import ValidationMessage from '@/components/common/input/validationMessage';
+import ModalLoading from '@/components/common/loading/modalLoading';
 import Modal from '@/components/common/modal/modal';
 import * as S from '@/components/projectInfo/ChangeOwnerModal/changeOwnerModal.style';
 
@@ -16,7 +17,7 @@ type TModalProps = {
 export default function ChangeOwnerModal({ onClose, projectId = 0, userId = 0 }: TModalProps) {
   const { useChangeOwn } = useChangeOwner();
   const queryClient = useQueryClient();
-  const { mutate: changeOwner } = useChangeOwn;
+  const { mutate: changeOwner, isPending } = useChangeOwn;
   const [errorMessage, setErrorMessage] = useState('');
   const handleChange = () => {
     changeOwner(
@@ -28,8 +29,8 @@ export default function ChangeOwnerModal({ onClose, projectId = 0, userId = 0 }:
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ['getProjectMember', projectId] });
           queryClient.invalidateQueries({ queryKey: ['getMemberEmail', projectId] });
+          queryClient.invalidateQueries({ queryKey: ['getProjectInfo', projectId] });
           onClose();
-          window.location.reload();
         },
         onError: (err) => {
           setErrorMessage(err.response?.data.message || 'An error occurred.');
@@ -39,6 +40,7 @@ export default function ChangeOwnerModal({ onClose, projectId = 0, userId = 0 }:
   };
   return (
     <Modal title="Do you want to delegate the room manager authority?" onClose={onClose}>
+      {isPending && <ModalLoading />}
       <S.ModalBox>
         <S.Content>As soon as you lose the room manager authority, you lose the right to modify or remove the project.</S.Content>
       </S.ModalBox>
@@ -47,7 +49,7 @@ export default function ChangeOwnerModal({ onClose, projectId = 0, userId = 0 }:
         <Button type="normal" color="white_square" onClick={onClose}>
           Cancel
         </Button>
-        <Button type="normal" color="blue" onClick={handleChange}>
+        <Button type="normal" color="blue" onClick={handleChange} disabled={isPending}>
           Delegrate
         </Button>
       </S.BtnWrapper>

--- a/src/components/projectInfo/deleteProjectModal/deleteProjectModal.tsx
+++ b/src/components/projectInfo/deleteProjectModal/deleteProjectModal.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+
+import { queryClient } from '@/apis/queryClient';
 
 import { useProjectInfo } from '@/hooks/projectInfo/useProjectInfo';
 
@@ -14,15 +18,18 @@ type TAuthModalProps = {
 };
 export default function DeleteProjectModal({ onClose }: TAuthModalProps) {
   const { projectId } = useParams();
+  const navigate = useNavigate();
   const { useDeleteProject } = useProjectInfo({ projectId: Number(projectId) });
-  const { mutate: deleteProjectMutate } = useDeleteProject;
+  const { mutate: deleteProjectMutate, isPending } = useDeleteProject;
   const [errorMessage, setErrorMessage] = useState('');
   const handleDelete = () => {
     deleteProjectMutate(
       { projectId: Number(projectId) },
       {
         onSuccess: () => {
-          window.location.href = '/project';
+          queryClient.invalidateQueries({ queryKey: QUERY_KEYS.PROJECT_LIST });
+          navigate('/project');
+          onClose();
         },
         onError: (error) => {
           setErrorMessage(error.response?.data.message || 'An error occurred.');
@@ -38,7 +45,7 @@ export default function DeleteProjectModal({ onClose }: TAuthModalProps) {
         <Button color={'white_square'} onClick={onClose}>
           Cancel
         </Button>
-        <Button color={'blue'} onClick={handleDelete}>
+        <Button color={'blue'} onClick={handleDelete} disabled={isPending}>
           Delete
         </Button>
       </S.ButtonBox>

--- a/src/components/projectInfo/deleteProjectModal/deleteProjectModal.tsx
+++ b/src/components/projectInfo/deleteProjectModal/deleteProjectModal.tsx
@@ -8,6 +8,7 @@ import { queryClient } from '@/apis/queryClient';
 import { useProjectInfo } from '@/hooks/projectInfo/useProjectInfo';
 
 import Button from '@/components/common/button/button';
+import ModalLoading from '@/components/common/loading/modalLoading';
 import Modal from '@/components/common/modal/modal';
 
 import * as S from './deleteProjectModal.style';
@@ -39,6 +40,7 @@ export default function DeleteProjectModal({ onClose }: TAuthModalProps) {
   };
   return (
     <Modal title={'Are you sure you want to remove the page?'} onClose={onClose} isExitButtonVisible={false}>
+      {isPending && <ModalLoading />}
       <S.Container>If you press the Remove button, it will never recover again and all data will be deleted.</S.Container>
       <S.ButtonBox>
         {errorMessage && <ValidataionMessage message={errorMessage} isError={true} />}

--- a/src/components/projectInfo/deleteTeamMember/deleteTeamMemberModal.tsx
+++ b/src/components/projectInfo/deleteTeamMember/deleteTeamMemberModal.tsx
@@ -5,6 +5,7 @@ import { useChangeOwner } from '@/hooks/projectInfo/useChangeOwner';
 
 import Button from '@/components/common/button/button';
 import ValidationMessage from '@/components/common/input/validationMessage';
+import ModalLoading from '@/components/common/loading/modalLoading';
 import Modal from '@/components/common/modal/modal';
 import * as S from '@/components/projectInfo/deleteTeamMember/deleteTeamMemberModal.style';
 
@@ -16,7 +17,7 @@ type TModalProps = {
 export default function DeleteTeamMember({ onClose, projectId = 0, email = '' }: TModalProps) {
   const { useDeleteMember } = useChangeOwner();
   const queryClient = useQueryClient();
-  const { mutate: deleteMember } = useDeleteMember;
+  const { mutate: deleteMember, isPending } = useDeleteMember;
   const [errorMessage, setErrorMessage] = useState('');
   const handleChange = () => {
     deleteMember(
@@ -37,6 +38,7 @@ export default function DeleteTeamMember({ onClose, projectId = 0, email = '' }:
   };
   return (
     <Modal title="Are you sure to remove the team member?" onClose={onClose}>
+      {isPending && <ModalLoading />}
       <S.ModalBox>
         <S.Content>If you press the Remove button, it will never recover again and all data will be deleted.</S.Content>
       </S.ModalBox>
@@ -45,7 +47,7 @@ export default function DeleteTeamMember({ onClose, projectId = 0, email = '' }:
         <Button type="normal" color="white_square" onClick={onClose}>
           Cancel
         </Button>
-        <Button type="normal" color="blue" onClick={handleChange}>
+        <Button type="normal" color="blue" onClick={handleChange} disabled={isPending}>
           Delete
         </Button>
       </S.BtnWrapper>

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -29,9 +29,9 @@ export default function LoginPage() {
   const navigate = useNavigate();
 
   const { useGetUserEmail } = useInvite();
-  const { data: emailData } = useGetUserEmail;
+  const { isSuccess } = useGetUserEmail;
 
-  if (emailData) {
+  if (isSuccess) {
     navigate('/project');
   }
 

--- a/src/pages/signup/signup.tsx
+++ b/src/pages/signup/signup.tsx
@@ -37,9 +37,9 @@ type TAPIFormValues = {
 function SignupPage() {
   const navigate = useNavigate();
   const { useGetUserEmail } = useInvite();
-  const { data: emailData } = useGetUserEmail;
+  const { isSuccess } = useGetUserEmail;
 
-  if (emailData) {
+  if (isSuccess) {
     navigate('/project');
   }
 


### PR DESCRIPTION
## 🚨 관련 이슈
[//]: # (작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다.)
#335 
## ✨ 변경사항
[//]: # (어떤 변경사항이 있었나요? 체크해주세요 !)
- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
[//]: # (작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다.)
- 모든 모달에 로딩 추가 및 pending 시 disabled 처리
- 불필요한 reload 제거 및 쿼리 키로  정보 바로 반영되도록 수정
- 로그아웃 시 window.location.replace를 통해 캐시 삭제. -> 뒤로가기 해도 이제 정보가 안보이도록 수정
- 로그인/회원가입 화면으로 접근한 사용자가 이전에 로그인한 이력(토큰값이 유효하게 남아있는 것)이 있다면 자동으로 /project로 이동시키는 로직을 기존 data가 불러와지는 가에서 isSuccess로 변경

## 😅 미완성 작업 
[//]: # (없다면 N/A)
N/A

## 📢 논의 사항 및 참고 사항 
[//]: # (리뷰어가 알면 좋은 내용을 작성해주세요.)
